### PR TITLE
Fix filename case in #include directives

### DIFF
--- a/src/DCCpp/Config.h
+++ b/src/DCCpp/Config.h
@@ -10,7 +10,7 @@ Part of DCC++ BASE STATION for the Arduino
 #ifndef __config_h
 #define __config_h
 
-#include "arduino.h"
+#include "Arduino.h"
 
 /////////////////////////////////////////////////////////////////////////////////////
 //

--- a/src/controllerDccpp.cpp
+++ b/src/controllerDccpp.cpp
@@ -173,7 +173,7 @@ DCC++ BASE STATION is configured through the Config.h file that contains all use
 **********************************************************************/
 
 #include "DcDccNanoController.h"
-#include "arduino.h"
+#include "Arduino.h"
 #include "ControllerDccpp.hpp"
 
 // SET UP COMMUNICATIONS INTERFACE - FOR STANDARD SERIAL, NOTHING NEEDS TO BE DONE


### PR DESCRIPTION
Incorrect capitalization of Arduino.h caused compilation to fail on filename case-sensitive operating systems like Linux.